### PR TITLE
RSA: added from_cfg method

### DIFF
--- a/pyformlang/rsa/__init__.py
+++ b/pyformlang/rsa/__init__.py
@@ -1,0 +1,28 @@
+"""
+:mod:`pyformlang.rsa`
+====================================
+
+This module deals with recursive automaton.
+
+References
+----------
+[1] Alur R., Etessami K., Yannakakis M. (2001) Analysis of Recursive State Machines. In: Berry G.,
+Comon H., Finkel A. (eds) Computer Aided Verification. CAV 2001.
+Lecture Notes in Computer Science, vol 2102.
+Springer, Berlin, Heidelberg. https://doi.org/10.1007/3-540-44585-4_18
+
+Available Classes
+-----------------
+
+:class:`~pyformlang.rsa.RecursiveAutomaton`
+    A recursive automaton
+:class:`~pyformlang.rsa.Box`
+    A constituent part of a recursive automaton
+
+"""
+
+
+from .recursive_automaton import RecursiveAutomaton
+from .box import Box
+
+__all__ = ["RecursiveAutomaton", "Box"]

--- a/pyformlang/rsa/box.py
+++ b/pyformlang/rsa/box.py
@@ -94,3 +94,9 @@ class Box:
             return True
 
         return False
+
+    def __eq__(self, other):
+        return self.is_equivalent_to(other)
+
+    def __hash__(self):
+        return self._label.__hash__()

--- a/pyformlang/rsa/tests/test_rsa.py
+++ b/pyformlang/rsa/tests/test_rsa.py
@@ -1,8 +1,10 @@
 import unittest
 
-from pyformlang.rsa.recursive_automaton import RecursiveAutomaton
 from pyformlang.finite_automaton.symbol import Symbol
 from pyformlang.regular_expression import Regex
+from pyformlang.cfg import CFG
+
+from pyformlang.rsa.recursive_automaton import RecursiveAutomaton
 from pyformlang.rsa.box import Box
 
 
@@ -15,7 +17,7 @@ class TestRSA(unittest.TestCase):
         rsa_1 = RecursiveAutomaton({Symbol("S")}, Symbol("S"), {box})
 
         self.assertEqual(rsa_1.get_number_of_boxes(), 1)
-        self.assertEqual(box.is_equivalent_to(rsa_1.get_box(Symbol("S"))), True)
+        self.assertEqual(box, rsa_1.get_box(Symbol("S")))
         self.assertEqual(rsa_1.labels, {Symbol("S")})
         self.assertEqual(rsa_1.initial_label, Symbol("S"))
 
@@ -23,7 +25,7 @@ class TestRSA(unittest.TestCase):
         rsa_2.add_box(box)
         rsa_2.change_initial_label(Symbol("S"))
 
-        self.assertEqual(rsa_2.is_equivalent_to(rsa_1), True)
+        self.assertEqual(rsa_2, rsa_1)
 
         # Checking to add a start label
         rsa_3 = RecursiveAutomaton(set(), Symbol("S"), {box})
@@ -36,30 +38,49 @@ class TestRSA(unittest.TestCase):
 
     def test_from_regex(self):
         # S -> a*
-        rsa_2 = RecursiveAutomaton.from_regex("a*", Symbol("S"))
+        rsa_2 = RecursiveAutomaton.from_regex(Regex("a*"), Symbol("S"))
 
         enfa = Regex("a*").to_epsilon_nfa()
         dfa = enfa.minimize()
         box = Box(dfa, Symbol("S"))
         rsa_1 = RecursiveAutomaton({Symbol("S")}, Symbol("S"), {box})
 
-        self.assertEqual(rsa_2.is_equivalent_to(rsa_1), True)
+        self.assertEqual(rsa_2, rsa_1)
 
     def test_is_equivalent_to(self):
         # S -> a* b*
-        rsa_1 = RecursiveAutomaton.from_regex("a* b*", Symbol("S"))
+        rsa_1 = RecursiveAutomaton.from_regex(Regex("a* b*"), Symbol("S"))
 
         # S -> a+ b+
-        rsa_2 = RecursiveAutomaton.from_regex("a a* b b*", Symbol("S"))
+        rsa_2 = RecursiveAutomaton.from_regex(Regex("a a* b b*"), Symbol("S"))
 
-        self.assertEqual(rsa_1.is_equivalent_to(rsa_2), False)
+        self.assertEqual(rsa_1 == rsa_2, False)
 
     def test_add_box(self):
-        rsa_1 = RecursiveAutomaton.from_regex("a* b*", Symbol("S"))
+        rsa_1 = RecursiveAutomaton.from_regex(Regex("a* b*"), Symbol("S"))
         new_box = Box(Regex("a*").to_epsilon_nfa().minimize(), Symbol("S"))
         rsa_1.add_box(new_box)
-        self.assertEqual(new_box.dfa.is_equivalent_to(rsa_1.get_box(Symbol("S")).dfa), True)
+        self.assertEqual(new_box.dfa, rsa_1.get_box(Symbol("S")).dfa)
         self.assertEqual(rsa_1.labels, {Symbol("S")})
+
+    def test_from_cfg(self):
+        # g1: S -> a S b | a b
+        rsa1_g1 = RecursiveAutomaton.from_cfg(CFG.from_text("S -> a S b | a b"))
+        rsa2_g1 = RecursiveAutomaton.from_regex(Regex("a S b | a b"), Symbol("S"))
+
+        self.assertEqual(rsa1_g1, rsa2_g1)
+
+        # g2: S -> a V b
+        #     V -> c S d | c d
+        rsa1_g2 = RecursiveAutomaton.from_cfg(CFG.from_text("S -> a V b\nV -> c S d | c d"))
+        self.assertEqual(rsa1_g2.get_number_of_boxes(), 2)
+        self.assertEqual(rsa1_g2.labels, {Symbol("S"), Symbol("V")})
+
+        dfa_S = Regex("a V b").to_epsilon_nfa().minimize()
+        self.assertEqual(rsa1_g2.get_box(Symbol("S")), Box(dfa_S, Symbol("S")))
+
+        dfa_V = Regex("c S d | c d").to_epsilon_nfa().minimize()
+        self.assertEqual(rsa1_g2.get_box(Symbol("V")), Box(dfa_V, Symbol("V")))
 
 
 if __name__ == '__main__':

--- a/pyformlang/rsa/tests/test_rsa.py
+++ b/pyformlang/rsa/tests/test_rsa.py
@@ -54,7 +54,7 @@ class TestRSA(unittest.TestCase):
         # S -> a+ b+
         rsa_2 = RecursiveAutomaton.from_regex(Regex("a a* b b*"), Symbol("S"))
 
-        self.assertEqual(rsa_1 == rsa_2, False)
+        self.assertNotEqual(rsa_1, rsa_2)
 
     def test_add_box(self):
         rsa_1 = RecursiveAutomaton.from_regex(Regex("a* b*"), Symbol("S"))
@@ -81,7 +81,3 @@ class TestRSA(unittest.TestCase):
 
         dfa_V = Regex("c S d | c d").to_epsilon_nfa().minimize()
         self.assertEqual(rsa1_g2.get_box(Symbol("V")), Box(dfa_V, Symbol("V")))
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Hello @Aunsiels

I propose a new method for RSA.

Example:
```cython
from pyformlang.cfg import CFG
from pyformlang.rsa import RecursiveAutomaton

my_rsa = RecursiveAutomaton.from_cfg(CFG.from_text("S -> a S b | a b"))
```