### PR TITLE
term "epsilon" spend a lot of space on graphviz diagrams, let replace it by ɛ 

### DIFF
--- a/pyformlang/finite_automaton/finite_automaton.py
+++ b/pyformlang/finite_automaton/finite_automaton.py
@@ -494,7 +494,10 @@ class FiniteAutomaton:
                 graph.add_edge(str(state.value) + "_starting",
                                state.value)
         for s_from, symbol, s_to in self._transition_function.get_edges():
-            graph.add_edge(s_from.value, s_to.value, label=symbol.value)
+            label_ = symbol.value
+            if label_ == 'epsilon':
+                label_ = 'ɛ'
+            graph.add_edge(s_from.value, s_to.value, label=label_)
         return graph
 
     @classmethod


### PR DESCRIPTION
term epsilon spend a lot of space on graphviz diagrams, 

![image](https://user-images.githubusercontent.com/1609739/170767912-cd7e56d7-2fc2-4469-b7f7-cd1ee540d5a9.png)

Will be better if should be replaced here with unicode epsilon → ɛ , will be more readable

![image](https://user-images.githubusercontent.com/1609739/170768086-14d519b1-3ea4-4cc5-abf4-1fec5a5f32c0.png)


