### PR TITLE
Fix '\\' escape bug in  PythonRegex

### DIFF
--- a/pyformlang/regular_expression/python_regex.py
+++ b/pyformlang/regular_expression/python_regex.py
@@ -21,7 +21,8 @@ TRANSFORMATIONS = {
     ".": "\\.",
     "$": "\\$",
     "\n": "",
-    " ": "\\ "
+    " ": "\\ ",
+    '\\' : '\\\\'
 }
 
 ESCAPED_PRINTABLES = [TRANSFORMATIONS.get(x, x)


### PR DESCRIPTION
Python regex has a bug such that the following code return (False, False):
```python
import pyformlang
import pyformlang.regular_expression
r = pyformlang.regular_expression.PythonRegex('.*')
r.accepts(']'),r.accepts('\\')
```
The problem is that '\\' is in list(string.printable), and thus you have to escape it (otherwise it messes up the join).
This PR fixes the above.