### PR TITLE
Bug in PythonRegex if you use an escaped dot

### DIFF
--- a/pyformlang/regular_expression/python_regex.py
+++ b/pyformlang/regular_expression/python_regex.py
@@ -198,7 +198,7 @@ class PythonRegex(regex.Regex):
         self._python_regex = "".join(regex_temp)
 
     def _preprocess_dot(self):
-        self._python_regex = self._python_regex.replace(".", DOT_REPLACEMENT)
+        self._python_regex = re.sub(r'(?<!\\)\.', DOT_REPLACEMENT, self._python_regex)
 
     def _preprocess_optional(self):
         regex_temp = []

--- a/pyformlang/regular_expression/python_regex.py
+++ b/pyformlang/regular_expression/python_regex.py
@@ -198,7 +198,8 @@ class PythonRegex(regex.Regex):
         self._python_regex = "".join(regex_temp)
 
     def _preprocess_dot(self):
-        self._python_regex = re.sub(r'(?<!\\)\.', DOT_REPLACEMENT, self._python_regex)
+        simple_replace = lambda x: DOT_REPLACEMENT
+        self._python_regex = re.sub(r'(?<!\\)\.', simple_replace, self._python_regex)
 
     def _preprocess_optional(self):
         regex_temp = []


### PR DESCRIPTION
The following code throws an error:
```python
import pyformlang
import pyformlang.regular_expression
r = pyformlang.regular_expression.PythonRegex('\\.')
```
This pull request fixes it