### PR TITLE
Fix #31

### DIFF
--- a/pyformlang/cfg/cfg.py
+++ b/pyformlang/cfg/cfg.py
@@ -1081,16 +1081,16 @@ class CFG:
                     body_component = body_component[5:-1]
                 else:
                     type_component = ""
-                if body_component[0] in string.ascii_uppercase or \
+                if body_component not in EPSILON_SYMBOLS or type_component \
+                     == "TER":
+                    body_ter = Terminal(body_component)
+                    terminals.add(body_ter)
+                    body.append(body_ter)
+                elif body_component[0] in string.ascii_uppercase or \
                         type_component == "VAR":
                     body_var = Variable(body_component)
                     variables.add(body_var)
                     body.append(body_var)
-                elif body_component not in EPSILON_SYMBOLS or type_component \
-                        == "TER":
-                    body_ter = Terminal(body_component)
-                    terminals.add(body_ter)
-                    body.append(body_ter)
             productions.add(Production(head, body))
 
     def is_normal_form(self):

--- a/pyformlang/cfg/cfg.py
+++ b/pyformlang/cfg/cfg.py
@@ -1081,16 +1081,19 @@ class CFG:
                     body_component = body_component[5:-1]
                 else:
                     type_component = ""
-                if body_component not in EPSILON_SYMBOLS or type_component \
-                     == "TER":
-                    body_ter = Terminal(body_component)
+                if not body_component[0].isupper() or type_component == "TER":
+                    if body_component in EPSILON_SYMBOLS:
+                        body_ter = Epsilon()
+                    else:
+                        body_ter = Terminal(body_component)
                     terminals.add(body_ter)
                     body.append(body_ter)
-                elif body_component[0] in string.ascii_uppercase or \
-                        type_component == "VAR":
+                elif body_component[0].isupper() or type_component == "VAR":
                     body_var = Variable(body_component)
                     variables.add(body_var)
                     body.append(body_var)
+                else:
+                    raise ValueError(f"Invalid rule definition: {body_component}")
             productions.add(Production(head, body))
 
     def is_normal_form(self):

--- a/pyformlang/cfg/cfg.py
+++ b/pyformlang/cfg/cfg.py
@@ -1081,14 +1081,13 @@ class CFG:
                     body_component = body_component[5:-1]
                 else:
                     type_component = ""
-                if not body_component[0].isupper() or type_component == "TER":
+                if type_component != "VAR" and (not body_component[0].isupper() or type_component == "TER" or body_component in EPSILON_SYMBOLS):
                     if body_component in EPSILON_SYMBOLS:
-                        body_ter = Epsilon()
-                    else:
-                        body_ter = Terminal(body_component)
+                        continue
+                    body_ter = Terminal(body_component)
                     terminals.add(body_ter)
                     body.append(body_ter)
-                elif body_component[0].isupper() or type_component == "VAR":
+                elif type_component != "TER" and (body_component[0].isupper() or type_component == "VAR"):
                     body_var = Variable(body_component)
                     variables.add(body_var)
                     body.append(body_var)

--- a/pyformlang/cfg/tests/test_cfg.py
+++ b/pyformlang/cfg/tests/test_cfg.py
@@ -769,6 +769,16 @@ class TestCFG:
         assert cfg.contains(["a", "b"])
         assert ["a", "b"] in cfg
 
+    def test_from_text3(self):
+        text = """
+        S  -> "TER:A" "TER:B" "VAR:a"
+        "VAR:a" -> "TER:A" | $
+        """
+        cfg = CFG.from_text(text)
+        assert cfg.contains(["A", "B"])
+        assert cfg.contains(["A", "B", "A"])
+
+
     def test_from_text_union(self):
         text = """
         "VAR:S" -> TER:a | b


### PR DESCRIPTION
The culprit was a mismatching control flow, which would zealously accept any uppercase as variable even inside TER notation.