### PR TITLE
Fix Typo in PythonRegex documentation

### DIFF
--- a/pyformlang/regular_expression/python_regex.py
+++ b/pyformlang/regular_expression/python_regex.py
@@ -63,9 +63,10 @@ class PythonRegex(regex.Regex):
     * Set of characters with []
     * Inverse set of character with [^...]
     * positive closure +
+    * Kleene star *
     * . for all printable characters
     * ? for optional character/group
-    * Repetition of characters with {m} and {n,m}q
+    * Repetition of characters with {m} and {n,m}
     * Shortcuts: \\d, \\s, \\w
 
     Parameters


### PR DESCRIPTION
I tested these locally and they appear to be correctly supported.